### PR TITLE
Fix bower.json to correct reference shCore.js as the main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "SyntaxHighlighter",
   "version": "3.0.9",
-  "main": "./scripts/shCore.js",
+  "main": "./src/js/shCore.js",
   "author": "Alex Gorbatchev <alex.gorbatchev@gmail.com> (http://alexgorbatchev.com)",
   "licenses": [
     {


### PR DESCRIPTION
This came up in here https://github.com/blittle/bower-installer/issues/95

Just a simple fix to correctly reference `shCore.js`
